### PR TITLE
Move-range semantic

### DIFF
--- a/backend/columnar.js
+++ b/backend/columnar.js
@@ -33,7 +33,7 @@ const VALUE_TYPE = {
 }
 
 // make* actions must be at even-numbered indexes in this list
-const ACTIONS = ['makeMap', 'set', 'makeList', 'del', 'makeText', 'inc', 'makeTable', 'link']
+const ACTIONS = ['makeMap', 'set', 'makeList', 'del', 'makeText', 'inc', 'makeTable', 'link', 'mov']
 
 const OBJECT_TYPE = {makeMap: 'map', makeList: 'list', makeText: 'text', makeTable: 'table'}
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -90,11 +90,6 @@ function processChangeRequest(state, opSet, request, startOp) {
         const value = elemIds[op.obj].valueOf(op.child)
         elemIds[op.obj] = elemIds[op.obj].removeKey(op.child)
 
-        // key is after child, but child is removed first, so idxKey is decreased by 1
-        // if (idxKey > idxChild) {
-        //   idxKey--
-        // }
-
         if (idxKey === 0) {
           op.key = '_head'
           elemIds[op.obj] = elemIds[op.obj].insertAfter(null, opId)

--- a/backend/index.js
+++ b/backend/index.js
@@ -77,8 +77,32 @@ function processChangeRequest(state, opSet, request, startOp) {
       if (typeof op.key !== 'number') {
         throw new TypeError(`Unexpected operation key: ${op.key}`)
       }
+      if (op.action === 'mov') {
+        if (typeof op.child !== 'number') {
+          throw new TypeError(`Unexpected operation child: ${op.child}`)
+        }
 
-      if (op.insert) {
+        // move from child to key
+        let idxChild = op.child
+        let idxKey = op.key
+
+        op.child = elemIds[op.obj].keyOf(op.child)
+        const value = elemIds[op.obj].valueOf(op.child)
+        elemIds[op.obj] = elemIds[op.obj].removeKey(op.child)
+
+        // key is after child, but child is removed first, so idxKey is decreased by 1
+        // if (idxKey > idxChild) {
+        //   idxKey--
+        // }
+
+        if (idxKey === 0) {
+          op.key = '_head'
+          elemIds[op.obj] = elemIds[op.obj].insertAfter(null, opId)
+        } else {
+          op.key = elemIds[op.obj].keyOf(idxKey - 1)
+          elemIds[op.obj] = elemIds[op.obj].insertAfter(op.key, opId)
+        }
+      } else if (op.insert) {
         if (op.key === 0) {
           op.key = '_head'
           elemIds[op.obj] = elemIds[op.obj].insertAfter(null, opId)

--- a/frontend/apply_patch.js
+++ b/frontend/apply_patch.js
@@ -261,6 +261,7 @@ function updateTextObject(patch, obj, updated) {
     if (!opId) throw new RangeError(`No default value at index ${key}`)
 
     // TODO Text object does not support conflicts. Should it?
+    // For moves that would be useful
     const oldValue = (elems[key].opId === opId) ? elems[key].value : undefined
     elems[key].value = getValue(patch.props[key][opId], oldValue, updated)
     elems[key].opId = opId

--- a/frontend/context.js
+++ b/frontend/context.js
@@ -378,6 +378,26 @@ class Context {
     this.applyPatch(patch.diffs, this.cache[ROOT_ID], this.updated)
   }
 
+  moveTo(path, idxSource, idxDest) {
+    const objectId = path.length === 0 ? ROOT_ID : path[path.length - 1].objectId
+    let list = this.getObject(objectId)
+    if (idxSource < 0 || idxDest < 0 || idxSource > list.length || idxDest > list.length) {
+      throw new RangeError(`moving from index ${idxSource} to index ${idxDest} is out of bounds for list of length ${list.length}`)
+    }
+    if (idxSource === idxDest) return
+
+    let patch = {diffs: {objectId: ROOT_ID, type: 'map'}}
+    let subpatch = this.getSubpatch(patch, path)
+    if (!subpatch.edits) subpatch.edits = []
+
+    this.addOp({action: 'mov', obj: objectId, key: idxDest, child: idxSource})
+    subpatch.edits.push({action: 'remove', index: idxSource})
+    subpatch.edits.push({action: 'insert', index: idxDest})
+    subpatch.props[idxDest] = {[this.actorId]: {value: 'magpie'}}
+
+    this.applyPatch(patch.diffs, this.cache[ROOT_ID], this.updated)
+  }
+
   /**
    * Updates the table object at path `path`, adding a new entry `row`.
    * Returns the objectId of the new row.

--- a/frontend/text.js
+++ b/frontend/text.js
@@ -149,6 +149,18 @@ class Text {
     }
     return this
   }
+
+  moveTo(idxSource, idxDest) {
+    if (this.context) {
+      this.context.moveTo(this.path, idxSource, idxDest)
+    } else if (!this[OBJECT_ID]) {
+      throw new TypeError('TODO')
+      this.elems.splice(index, numDelete)
+    } else {
+      throw new TypeError('Automerge.Text object cannot be modified outside of a change block')
+    }
+    return this
+  }
 }
 
 // Read-only methods that can delegate to the JavaScript built-in array

--- a/test/backend_test.js
+++ b/test/backend_test.js
@@ -520,7 +520,7 @@ describe('Automerge.Backend', () => {
       // TODO is order important here?
       assert.deepStrictEqual(new Set(changes[1].ops[3].pred), new Set(['2@111111', '3@111111']))
       assert.deepStrictEqual(new Set(changes[1].ops[4].pred), new Set(['3@111111', '4@111111', '5@111111']))
-      assert.deepStrictEqual(new Set(changes[2].ops[0].pred), new Set(['4@111111', '6@111111']))
+      assert.deepStrictEqual(new Set(changes[2].ops[0].pred), new Set(['2@111111', '6@111111']))
     })
   })
 

--- a/test/context_test.js
+++ b/test/context_test.js
@@ -290,6 +290,28 @@ describe('Proxying context', () => {
       ])
     })
 
+    it('should support moving list elements', () => {
+      context.moveTo([{key: 'birds', objectId: listId}], 1, 0)
+      assert(applyPatch.calledOnce)
+      assert.deepStrictEqual(applyPatch.firstCall.args[0], {
+        objectId: ROOT_ID, type: 'map', props: {
+          birds: {
+            actor1: {
+              objectId: listId, type: 'list', props: {
+                0: {[context.actorId]: {value: 'magpie'}}
+              }, edits: [
+                {action: 'remove', index: 1}, {action: 'insert', index: 0}
+              ]
+            }
+          }
+        }
+      })
+      assert.deepStrictEqual(context.ops, [
+        // move from child to key
+        {obj: listId, action: 'mov', child: 1, key: 0}
+      ])
+    })
+
     it('should support list splicing', () => {
       context.splice([{key: 'birds', objectId: listId}], 0, 1, ['starling', 'goldfinch'])
       assert(applyPatch.calledOnce)

--- a/test/frontend_test.js
+++ b/test/frontend_test.js
@@ -626,6 +626,32 @@ describe('Automerge.Frontend', () => {
       assert.deepStrictEqual(doc2, {birds: ['goldfinch']})
     })
 
+    it('should move list elements', () => {
+      const birds = uuid(), actor = uuid()
+      const patch1 = {
+        version: 1, clock: {[actor]: 1}, canUndo: false, canRedo: false,
+        diffs: {objectId: ROOT_ID, type: 'map', props: {birds: {[actor]: {
+                objectId: birds, type: 'list',
+                edits: [{action: 'insert', index: 0}, {action: 'insert', index: 1}],
+                props: {
+                  0: {[actor]: {value: 'chaffinch'}},
+                  1: {[actor]: {value: 'goldfinch'}}
+                }
+              }}}}
+      }
+      const patch2 = {
+        version: 2, clock: {[actor]: 2}, canUndo: false, canRedo: false,
+        diffs: {objectId: ROOT_ID, type: 'map', props: {birds: {[actor]: {
+                objectId: birds, type: 'list', props: {},
+                edits: [{action: 'remove', index: 0}]
+              }}}}
+      }
+      const doc1 = Frontend.applyPatch(Frontend.init(), patch1)
+      const doc2 = Frontend.applyPatch(doc1, patch2)
+      assert.deepStrictEqual(doc1, {birds: ['chaffinch', 'goldfinch']})
+      assert.deepStrictEqual(doc2, {birds: ['goldfinch']})
+    })
+
     it('should apply updates at different levels of the object tree', () => {
       const counts = uuid(), details = uuid(), detail1 = uuid(), actor = uuid()
       const patch1 = {

--- a/test/text_test.js
+++ b/test/text_test.js
@@ -315,6 +315,32 @@ describe('Automerge.Text', () => {
     assert.strictEqual(s1.text.toString(), s2.text.toString())
   })
 
+  it('should support concurrent ambiguous moving with consecutive insert', () => {
+    let s1 = Automerge.change(Automerge.init('111111'), doc => doc.text = new Automerge.Text())
+    s1 = Automerge.change(s1, doc => doc.text.insertAt(0, 'a', 'b', 'c', 'd'))
+    let s2 = Automerge.merge(Automerge.init('222222'), s1)
+    s1 = Automerge.change(s1, doc => doc.text.moveTo(0, 1))
+    s1 = Automerge.change(s1, doc => doc.text.insertAt(2, 'X'))
+
+    assert.strictEqual(s1.text.length, 5)
+    assert.strictEqual(s1.text.toString(), 'baXcd')
+
+    s2 = Automerge.change(s2, doc => doc.text.moveTo(1, 2))
+
+    assert.strictEqual(s2.text.length, 4)
+    assert.strictEqual(s2.text.toString(), 'acbd')
+
+    s1 = Automerge.merge(s1, s2)
+    assert.strictEqual(s1.text.length, 5)
+    assertEqualsOneOf(s1.text.toString(), 'aXcbd', 'cbaXd')
+
+    s2 = Automerge.merge(s2, s1)
+    assert.strictEqual(s2.text.length, 5)
+    assertEqualsOneOf(s2.text.toString(), 'aXcbd', 'cbaXd')
+
+    assert.strictEqual(s1.text.toString(), s2.text.toString())
+  })
+
   it('should support concurrent conflicting moves', () => {
     s1 = Automerge.change(s1, doc => doc.text.insertAt(0, 'a', 'b', 'c', 'd'))
     let s2 = Automerge.merge(Automerge.init(), s1)

--- a/test/text_test.js
+++ b/test/text_test.js
@@ -219,6 +219,46 @@ describe('Automerge.Text', () => {
     assert.strictEqual(s1.text.toString(), 'ac')
   })
 
+  it('should support moving back to head', () => {
+    s1 = Automerge.change(s1, doc => doc.text.insertAt(0, 'a', 'b', 'c'))
+    s1 = Automerge.change(s1, doc => doc.text.moveTo(1, 0))
+    assert.strictEqual(s1.text.length, 3)
+    assert.strictEqual(s1.text.get(0), 'b')
+    assert.strictEqual(s1.text.get(1), 'a')
+    assert.strictEqual(s1.text.get(2), 'c')
+    assert.strictEqual(s1.text.toString(), 'bac')
+  })
+
+  it('should support moving back to middle', () => {
+    s1 = Automerge.change(s1, doc => doc.text.insertAt(0, 'a', 'b', 'c'))
+    s1 = Automerge.change(s1, doc => doc.text.moveTo(2, 1))
+    assert.strictEqual(s1.text.length, 3)
+    assert.strictEqual(s1.text.toString(), 'acb')
+    assert.strictEqual(s1.text.get(0), 'a')
+    assert.strictEqual(s1.text.get(1), 'c')
+    assert.strictEqual(s1.text.get(2), 'b')
+  })
+
+  it('should support moving forward from head', () => {
+    s1 = Automerge.change(s1, doc => doc.text.insertAt(0, 'a', 'b', 'c'))
+    s1 = Automerge.change(s1, doc => doc.text.moveTo(0, 1))
+    assert.strictEqual(s1.text.length, 3)
+    assert.strictEqual(s1.text.toString(), 'bac')
+    assert.strictEqual(s1.text.get(0), 'b')
+    assert.strictEqual(s1.text.get(1), 'a')
+    assert.strictEqual(s1.text.get(2), 'c')
+  })
+
+  it('should support moving forward to end', () => {
+    s1 = Automerge.change(s1, doc => doc.text.insertAt(0, 'a', 'b', 'c'))
+    s1 = Automerge.change(s1, doc => doc.text.moveTo(1, 2))
+    assert.strictEqual(s1.text.length, 3)
+    assert.strictEqual(s1.text.toString(), 'acb')
+    assert.strictEqual(s1.text.get(0), 'a')
+    assert.strictEqual(s1.text.get(1), 'c')
+    assert.strictEqual(s1.text.get(2), 'b')
+  })
+
   it("should support implicit and explicit deletion", () => {
     s1 = Automerge.change(s1, doc => doc.text.insertAt(0, "a", "b", "c"))
     s1 = Automerge.change(s1, doc => doc.text.deleteAt(1))


### PR DESCRIPTION
Experimenting with move semantics

Current status:

* simple moves of single elements seem to work now
* new action 'mov' to encode moves in a single action
  * uses `key` and `child` to encode operation
  * moves from child to key
* concurrent moves
  * ambiguous case
  * conflicting case

Work in progress

* honor moves in insert operations

Untested:

* multiple moves 

Still figuring out:

* moves are encoded as insert/remove on edits level, not sure if that works in the general case

Planned:

* somehow define a range of elements to create an atomic move of a whole range